### PR TITLE
Fix bug in the email

### DIFF
--- a/src/main/java/com/agilethought/internship/sso/validator/user/NewUserValidator.java
+++ b/src/main/java/com/agilethought/internship/sso/validator/user/NewUserValidator.java
@@ -6,6 +6,8 @@ import com.agilethought.internship.sso.repository.RepositoryApplication;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Locale;
+
 import static com.agilethought.internship.sso.exception.errorhandling.ErrorMessage.ALREADY_EXISTING_EMAIL;
 
 @Service
@@ -18,7 +20,7 @@ public class NewUserValidator {
 
     public void validate(User user) {
         userDataValidator.validate(user);
-        validateUniqueEmail(user.getEmail());
+        validateUniqueEmail(user.getEmail().toLowerCase());
     }
 
     private void validateUniqueEmail(String email) {


### PR DESCRIPTION
When we store a new user, the user's email is store in lowercase, and the problem with this is when we want to store the same email but with some uppercase letters because that email doesn't exist and that email will store.

So in this PR, we validate the email in lowercase.

![imagen](https://user-images.githubusercontent.com/78741607/117033940-7584b480-acc8-11eb-9f3f-b195852e204f.png)
![imagen](https://user-images.githubusercontent.com/78741607/117034027-859c9400-acc8-11eb-8c43-e876d34cc5da.png)
![imagen](https://user-images.githubusercontent.com/78741607/117034088-951bdd00-acc8-11eb-8bb5-730a397fa733.png)
